### PR TITLE
feat: preserve existing env vars when deploying new revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 This action type will create a new deployment if no deployment with the provided project, location, and name has been created before. If a deployment already exists, it will deploy a new revision with the new provided configuration.
 
+If `env` is provided, it will override all existing environment variables. If env is not provided, the deployment will retain the existing environment variables to prevent accidental deletion.
+
 **Inputs:**
 
 | Parameter | Description |
@@ -23,7 +25,7 @@ This action type will create a new deployment if no deployment with the provided
 | `image` | **Required** docker image to deploy |
 | `port` | **Optional** deployment port, default is 80 |
 | `type` | **Optional** deployment type, default is 'WebService'. Supported types: WebService, Worker, Cronjob. |
-| `env` | **Optional** environment variables in YAML format |
+| `env` | **Optional** environment variables in YAML format. If omitted, existing environment variables will be retained. |
 
 **Environment variables:**
 

--- a/src/action/deployNewRevision.ts
+++ b/src/action/deployNewRevision.ts
@@ -25,17 +25,55 @@ export const deployNewRevision = async (): Promise<void> => {
       !createResponse.ok &&
       createResponse.error?.code === ErrorCode.DEPLOYMENT_NAME_ALREADY_EXISTS
     ) {
-      const deployResponse = await DeploymentService.deploy(input as DeployNewRevisionRequest);
-      if (!deployResponse.ok) {
-        if (!deployResponse.error || Object.keys(deployResponse.error).length === 0) {
-          core.setFailed(`Deploying the new revision failed due to an unexpected error`);
+      // env is provided - override all environment variables
+      if (input.env && Object.keys(input.env).length > 0) {
+        const deployResponse = await DeploymentService.deploy(input as DeployNewRevisionRequest);
+        if (!deployResponse.ok) {
+          if (!deployResponse.error || Object.keys(deployResponse.error).length === 0) {
+            core.setFailed(`Deploying the new revision failed due to an unexpected error`);
+            return;
+          }
+          core.setFailed(
+            ` ${deployResponse.error.code}: ${deployResponse.error.message}` +
+              (deployResponse.error.items ? ` (error causes: ${deployResponse.error.items})` : ''),
+          );
           return;
         }
-        core.setFailed(
-          ` ${deployResponse.error.code}: ${deployResponse.error.message}` +
-            (deployResponse.error.items ? ` (error causes: ${deployResponse.error.items})` : ''),
-        );
-        return;
+      } else {
+        // env is not provided - get exist env to avoid deleting existing env vars
+        const getResponse = await DeploymentService.get({
+          project: input.project,
+          location: input.location,
+          name: input.name,
+        } as GetDeploymentRequest);
+        if (!getResponse.ok) {
+          if (!getResponse.error || Object.keys(getResponse.error).length === 0) {
+            core.setFailed(`Getting the deployment failed due to an unexpected error`);
+            return;
+          }
+          core.setFailed(
+            ` ${getResponse.error.code}: ${getResponse.error.message}` +
+              (getResponse.error.items ? ` (error causes: ${getResponse.error.items})` : ''),
+          );
+          return;
+        }
+
+        if (getResponse.result?.env) {
+          input.env = getResponse.result.env;
+        }
+
+        const deployResponse = await DeploymentService.deploy(input as DeployNewRevisionRequest);
+        if (!deployResponse.ok) {
+          if (!deployResponse.error || Object.keys(deployResponse.error).length === 0) {
+            core.setFailed(`Deploying the new revision failed due to an unexpected error`);
+            return;
+          }
+          core.setFailed(
+            ` ${deployResponse.error.code}: ${deployResponse.error.message}` +
+              (deployResponse.error.items ? ` (error causes: ${deployResponse.error.items})` : ''),
+          );
+          return;
+        }
       }
     } else {
       if (!createResponse.ok) {

--- a/src/utils/envParser.ts
+++ b/src/utils/envParser.ts
@@ -1,7 +1,7 @@
-export const parseEnvInput = (envInput: string): Record<string, string> => {
-  if (!envInput.trim()) return {};
+export const parseEnvInput = (envInput: string): Record<string, string> | null => {
+  if (!envInput.trim()) return null;
 
-  return envInput
+  const result = envInput
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => line && line.includes(':'))
@@ -18,4 +18,6 @@ export const parseEnvInput = (envInput: string): Record<string, string> => {
       },
       {} as Record<string, string>,
     );
+
+  return Object.keys(result).length > 0 ? result : null;
 };


### PR DESCRIPTION
ensure that when a new revision is deployed, existing environment variables are retained if no new env variables are provided. If `env` is specified, it will override all environment variables; otherwise, the existing ones will be fetched and used.