### PR TITLE
feat(env): support standard .env format and file reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 This action type will create a new deployment if no deployment with the provided project, location, and name has been created before. If a deployment already exists, it will deploy a new revision with the new provided configuration.
 
-If `env` is provided, it will override all existing environment variables. If env is not provided, the deployment will retain the existing environment variables to prevent accidental deletion.
+If `env` or `env_file` is provided, it will be merged with existing environment variables (with new values taking precedence over existing ones with the same key). If neither is provided, the deployment will retain all existing environment variables unchanged.
 
 **Inputs:**
 
@@ -25,7 +25,8 @@ If `env` is provided, it will override all existing environment variables. If en
 | `image` | **Required** docker image to deploy |
 | `port` | **Optional** deployment port, default is 80 |
 | `type` | **Optional** deployment type, default is 'WebService'. Supported types: WebService, Worker, Cronjob. |
-| `env` | **Optional** environment variables in YAML format. If omitted, existing environment variables will be retained. |
+| `env` | **Optional** environment variables in standard `KEY=VALUE` format or YAML-like `KEY: VALUE` format. Each variable should be on a new line. If both `env` and `env_file` are provided, `env_file` takes precedence. |
+| `env_file` | **Optional** path to an environment file. Supports both .env format (`KEY=VALUE`) and YAML-like format (`KEY: VALUE`). Comments (lines starting with #) are ignored. |
 
 **Environment variables:**
 
@@ -54,7 +55,8 @@ The new cloned deployment will have a new name and image, with its configuration
 | `name` | **Required** deployment name that is to be cloned |
 | `image` | **Required** docker image to deploy |
 | `new_name`| **Optional** new deployment name. Randomly generated if a new deployment name is not provided |
-| `env` | **Optional** environment variables in YAML format |
+| `env` | **Optional** environment variables in standard `KEY=VALUE` format or YAML-like `KEY: VALUE` format. Each variable should be on a new line. |
+| `env_file` | **Optional** path to an environment file. Supports both formats. |
 
 **Environment variables:**
 
@@ -89,7 +91,101 @@ The new cloned deployment will have a new name and image, with its configuration
 
 **Outputs:** None
 
-## Example
+## Environment Variable Format
+The action supports two formats for environment variables:
+
+### Standard .env Format (Recommended)
+This is the standard format used in .env files:
+```
+# This is a comment and will be ignored
+PORT=80
+DB_URL=localhost:5432
+API_KEY=your-api-key
+```
+
+### YAML-like Format (Legacy Support)
+For backward compatibility, the action also supoort YAML-like format:
+```
+PORT: 80
+DB_URL: localhost:5432
+API_KEY: your-api-key
+```
+
+Both formats can be used interchangeably in either `env` or `env_file`. 
+You can even mix both formats in the same input, though using one consistent format is recommended.
+You can provide these variables in two ways:
+1. Using an `env_file` - Point to a file containing your environment variables
+2. Using inline `env` - Specify the variables directly in your workflow file
+
+### Behavior with Existing Deployments
+When updating an existing deployment:
+
+- New environment variables will be added to the existing ones
+- Existing environment variables with the same keys will be updated
+- Existing environment variables with different keys will be preserved
+
+## Examples
+### Using an .env file
+
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Nortezh/nortezh-action@v1
+        with:
+          action: deployment.create-revision
+          project: project-test
+          location: nortezh-stag
+          name: deployment-name-1
+          image: nginx
+          port: 80
+          type: WebService
+          env_file: .env
+        env:
+          SA_AUTH_EMAIL: ${{ secrets.SA_AUTH_EMAIL }}
+          SA_AUTH_KEY: ${{ secrets.SA_AUTH_KEY }}
+```
+
+### Using inline environment variables (with standard .env format)
+
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Nortezh/nortezh-action@v1
+        with:
+          action: deployment.create-revision
+          project: project-test
+          location: nortezh-stag
+          name: deployment-name-1
+          image: nginx
+          port: 80
+          type: WebService
+          env: |
+            PORT=80
+            DB_URL=localhost:5432
+        env:
+          SA_AUTH_EMAIL: ${{ secrets.SA_AUTH_EMAIL }}
+          SA_AUTH_KEY: ${{ secrets.SA_AUTH_KEY }}
+```
+
+### Using inline environment variables (with YAML-like format)
 
 ```yaml
 name: Deploy
@@ -119,3 +215,16 @@ jobs:
           SA_AUTH_EMAIL: ${{ secrets.SA_AUTH_EMAIL }}
           SA_AUTH_KEY: ${{ secrets.SA_AUTH_KEY }}
 ```
+
+## Error Handling
+When using `env_file`, the action will:
+
+- Check if the file exists at the specified path
+- Attempt to parse the file content as environment variables
+- Log any errors that occur during the process
+- Fall back to the inline env parameter if file reading fails
+
+Common errors that might occur:
+
+- File not found at the specified path
+- Invalid format in the environment file

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,9 @@ inputs:
   env:
     description: 'Environment variables'
     required: false
+  env_file:
+    description: 'Path to environment file (.env format)'
+    required: false
 
 outputs:
   public_url:

--- a/src/utils/envParser.ts
+++ b/src/utils/envParser.ts
@@ -1,18 +1,31 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
 export const parseEnvInput = (envInput: string): Record<string, string> | null => {
   if (!envInput.trim()) return null;
 
   const result = envInput
     .split('\n')
     .map((line) => line.trim())
-    .filter((line) => line && line.includes(':'))
+    .filter((line) => line && !line.startsWith('#'))
     .reduce(
       (acc, line) => {
-        const [key, ...valueParts] = line.split(':');
-        const keyTrimmed = key.trim();
-        const valueTrimmed = valueParts.join(':').trim();
+        if (line.includes('=')) {
+          const [key, ...valueParts] = line.split('=');
+          const keyTrimmed = key.trim();
+          const valueTrimmed = valueParts.join('=').trim();
 
-        if (keyTrimmed && valueTrimmed) {
-          acc[keyTrimmed] = valueTrimmed;
+          if (keyTrimmed && valueTrimmed) {
+            acc[keyTrimmed] = valueTrimmed;
+          }
+        } else if (line.includes(':')) {
+          const [key, ...valueParts] = line.split(':');
+          const keyTrimmed = key.trim();
+          const valueTrimmed = valueParts.join(':').trim();
+
+          if (keyTrimmed && valueTrimmed) {
+            acc[keyTrimmed] = valueTrimmed;
+          }
         }
         return acc;
       },
@@ -20,4 +33,36 @@ export const parseEnvInput = (envInput: string): Record<string, string> | null =
     );
 
   return Object.keys(result).length > 0 ? result : null;
+};
+
+export const readEnvFile = (
+  filePath: string = '.env',
+): {
+  data: Record<string, string> | null;
+  error: string | null;
+} => {
+  try {
+    const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(process.cwd(), filePath);
+
+    if (!fs.existsSync(absolutePath)) {
+      return {
+        data: null,
+        error: `Environment file not found: ${absolutePath}`,
+      };
+    }
+
+    const fileContent = fs.readFileSync(absolutePath, 'utf-8');
+    const parsedEnv = parseEnvInput(fileContent);
+
+    return {
+      data: parsedEnv,
+      error: null,
+    };
+  } catch (error) {
+    const errorMessage = `Error reading environment file: ${error instanceof Error ? error.message : String(error)}`;
+    return {
+      data: null,
+      error: errorMessage,
+    };
+  }
 };


### PR DESCRIPTION
- add support for standard `KEY=VALUE` environment variable format
- implement ability to read variables from .env files via `env_file` parameter
- update environment handling to merge with existing vars for deployments
- maintain backwards compatibility with YAML-like format
- update documentation with examples for both inline and file-based vars